### PR TITLE
package.json: fix links to the fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/3rd-Eden/diagnostics.git"
+    "url": "git://github.com/DABH/diagnostics.git"
   },
   "keywords": [
     "debug",
@@ -33,9 +33,9 @@
   "author": "Arnout Kazemier",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/3rd-Eden/diagnostics/issues"
+    "url": "https://github.com/DABH/diagnostics/issues"
   },
-  "homepage": "https://github.com/3rd-Eden/diagnostics",
+  "homepage": "https://github.com/DABH/diagnostics",
   "devDependencies": {
     "assume": "2.3.x",
     "asyncstorageapi": "^1.0.2",


### PR DESCRIPTION
@DABH I didn't touch the other links, but these ones wrongfully pointed to the upstream repo on the npm page :)